### PR TITLE
refactor: Migração do ETL de Pandas para Polars para Performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,140 @@
-# sia-sus
+### Projeto SIA-SUS: Extração e Processamento de Dados AM 2024
+
+Este projeto realiza a extração, concatenação e processamento de dados do grupo AM (APAC de Medicamentos) do SUS para o ano de 2024. O objetivo é demonstrar boas práticas de ETL, manipulação eficiente de grandes volumes de dados e refatoração de código para performance, utilizando o Polars para processamento em paralelo.
+
+## Estrutura  do  projeto
+
+sia-sus/
+├── extract/
+│   └── sia_extraction.py       # Extração de dados do SIA via PySUS
+├── transform/
+│   ├── process_data.py         # Concatenação e merge inicial com Polars LazyFrame
+│   └── process_brazil.py       # Refatoração e tipagem (Colunas, Datas, Compressão ZSTD)
+├── data/
+│   ├── raw/                    # Arquivos .dbc brutos baixados (AM/2024/<UF>/)
+│   └── processed/              # Arquivo Parquet consolidado e tratado
+├── main.py                     # Orquestração completa do fluxo (ETL)
+└── requirements.txt            # Dependências do projeto
+
+
+## Fluxo do trabalho
+
+## 1- Extração de dados
+
+Baixa arquivos do grupo AM (APAC de Medicamentos) para todas as UFs do Brasil usando pysus. e salva  na  pasta data/raw/AM/2024/<UF>/
+
+# Como executar
+
+# Execução completa do ETL
+python3 main.py
+
+# Este script orquestra os passos 1, 2 e 3 em sequência.
+
+## 2 - Concatenação dos arquivos
+
+Lê todos os arquivos baixados anteriormente e concatena em um único arquivo parquet.
+Usei polars e lazyframe par facilitar performance. Salva o arquivo concatenado  na pasta data/processed.
+
+# Como executar
+
+python3 transform/process_data.py
+
+## 3 - Refatoração e tratamento de dados
+
+Renomeia as colunas para  nomes mais simples, aplica tipo de dado correto(nos dados  brutos todas estão como tipo string). Salva o arquivo Parquet final usando compressão ZSTD afim de melhorar a performance de I/O. O arquivo final, com aproximadamente 35 milhões de linhas, está pronto para análises futuras e apresenta um tamanho reduzido de cerca de ~1.1 GB.
+
+### Dicionário dos dados orignal SIA-SUS
 
 [Dicionário de Dados](https://github.com/carolinajacoby/sia-sus/blob/main/docs/Dicionario_Dados.md)
+
+## Mapeamento de Campos de Dados (Original vs. Descritivo)
+
+| Nome Original | Nome Atualizado/Descritivo |
+| :--- | :--- |
+| **AP_MVM** | data\_movimento |
+| **AP_CONDIC** | tipo\_gestao |
+| **AP_GESTAO** | codigo\_uf\_municipio\_gestao |
+| **AP_CODUNI** | codigo\_estabelecimento |
+| **AP_AUTORIZ** | numero\_apac |
+| **AP_CMP** | data\_atendimento |
+| **AP_PRIPAL** | procedimento\_principal |
+| **AP_VL_AP** | valor\_apac |
+| **AP_UFMUN** | uf\_municipio\_estabelecimento |
+| **AP_TPUPS** | tipo\_estabelecimento |
+| **AP_TIPPRE** | tipo\_prestador |
+| **AP_MN_IND** | manutencao\_individual |
+| **AP_CNPJCPF** | cnpj\_estabelecimento |
+| **AP_CNPJMNT** | cnpj\_mantenedora |
+| **AP_CNSPCN** | cns\_paciente |
+| **AP_COIDADE** | codigo\_idade |
+| **AP_NUIDADE** | idade |
+| **AP_SEXO** | sexo |
+| **AP_RACACOR** | raca\_cor |
+| **AP_MUNPCN** | uf\_municipio\_residencia |
+| **AP_UFNACIO** | codigo\_nacionalidade |
+| **AP_CEPPCN** | cep |
+| **AP_UFDIF** | uf\_diferente |
+| **AP_MNDIF** | municipio\_diferente |
+| **AP_DTINIC** | data\_inicio |
+| **AP_DTFIM** | data\_fim |
+| **AP_TPATEN** | tipo\_atendimento |
+| **AP_TPAPAC** | indicador\_apac |
+| **AP_MOTSAI** | motivo\_saida |
+| **AP_OBITO** | obito |
+| **AP_ENCERR** | encerramento |
+| **AP_PERMAN** | permanencia |
+| **AP_ALTA** | alta |
+| **AP_TRANSF** | transferencia |
+| **AP_DTOCOR** | data\_ocorrencia |
+| **AP_CODEMI** | codigo\_orgao\_emissor |
+| **AP_CATEND** | carater\_atendimento |
+| **AP_APACANT** | numero\_apac\_anterior |
+| **AP_UNISOL** | estabelecimento\_solicitante |
+| **AP_DTSOLIC** | data\_solicitacao |
+| **AP_DTAUT** | data\_autorizacao |
+| **AP_CIDCAS** | cid\_causas\_associadas |
+| **AP_CIDPRI** | cid\_principal |
+| **AP_CIDSEC** | cid\_secundario |
+| **AP_ETNIA** | etnia |
+| **AM_PESO** | peso |
+| **AM_ALTURA** | altura |
+| **AM_TRANSPL** | transplante |
+| **AM_QTDTRAN** | quantidade\_transplantes |
+| **AM_GESTANT** | gestante |
+
+
+# Como executar
+
+python3 transform/process_brazil.py
+
+============================================================
+
+### Instalação e  dependências
+
+## 1 - Ambiente virtual
+
+Criar e ativar ambiente virtual do python
+
+# Como executar
+
+python3 -m venv venv
+source venv/bin/activate  # Linux/macOS
+venv\Scripts\activate     # Windows
+
+### 2 - Instalar dependências
+
+pip install -r requirements.txt
+
+## Principais dependências
+
+[Python 3.12](https://www.python.org/downloads/)
+[Polars](https://www.pola.rs/)
+[PySus](https://pysus.readthedocs.io/)
+
+============================================================
+
+---
+## Licença
+
+Este projeto está licenciado sob a Licença MIT.
+

--- a/analise_exploratoria.ipynb
+++ b/analise_exploratoria.ipynb
@@ -1,17 +1,49 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "254f0e83",
+   "metadata": {},
+   "source": [
+    "# Importar as bibliotecas necessaŕias"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "4c5d1667",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "\n",
+    "\n",
+    "import polars as pl\n",
+    "import matplotlib.pyplot as plt\n",
+    "import seaborn as sns\n",
+    "\n",
+    "# Configurações visuais do sns\n",
+    "sns.set(style=\"whitegrid\")\n",
+    "plt.rcParams[\"figure.figsize\"] = (12, 6)"
+   ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "venv (3.12.3)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/main.py
+++ b/main.py
@@ -1,10 +1,14 @@
+import time
+from pathlib import Path
 from extract.sia_extraction import baixar_am_2024
-from transform import process_data  
+from transform import process_data
+from transform import process_brazil
 
 def main():
+    start_time = time.time()
+
     # --- ETAPA 1: EXTRAÇÃO (DOWNLOAD) ---
     print("--- INICIANDO ETAPA DE EXTRAÇÃO DE DADOS ---")
-    
     uf_list = None  # None = todas as UFs
     resultados = baixar_am_2024(uf_list=uf_list)
 
@@ -12,14 +16,26 @@ def main():
     for uf, arquivos in resultados.items():
         print(f"{uf}: {len(arquivos)} arquivos baixados")
 
-    # --- ETAPA 2: PROCESSAMENTO (CONVERSÃO PARA PARQUET) ---
-    print("\n--- INICIANDO PROCESSAMENTO DOS ARQUIVOS PARA PARQUET ---")
-    
-    # Chama a função 'main' definida dentro do módulo 'process_data'.
-    # Ela irá ler os arquivos DBC na pasta data/raw/AM/2024 e salvar o Parquet.
+    # --- ETAPA 2: CONCATENAÇÃO E COMPRESSÃO (Polars) ---
+    print("\n--- INICIANDO CONCATENAÇÃO E COMPRESSÃO COM POLARS ---")
     process_data.main()
 
-    print("\n--- FLUXO DE TRABALHO CONCLUÍDO COM SUCESSO ---")
+    # --- ETAPA 3: TRATAMENTO DE TIPOS E DATAS (process_brazil) ---
+    print("\n--- INICIANDO TRATAMENTO DE TIPOS E DATAS ---")
+    process_brazil.main()
+
+    # --- MÉTRICAS DE DESEMPENHO ---
+    elapsed_time = (time.time() - start_time) / 60
+    print(f"\n Tempo total de execução: {elapsed_time:.2f} minutos")
+
+    # Arquivo final tratado
+    processed_file = Path("data/processed/am_2024_tratado.zstd.parquet")
+    if processed_file.exists():
+        size_gb = processed_file.stat().st_size / (1024**3)
+        print(f"Tamanho do arquivo final tratado: {size_gb:.2f} GB")
+
+    print("\nFLUXO DE TRABALHO CONCLUÍDO COM SUCESSO")
+
 
 if __name__ == "__main__":
     main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,33 +1,16 @@
-aioftp==0.21.4
-bigtree==0.12.5
-certifi==2025.10.5
-cffi==1.17.1
-cramjam==2.11.0
-dateparser==1.2.2
-dbfread==2.0.7
-elasticsearch==7.16.2
-fastparquet==2024.11.0
-fsspec==2025.9.0
-humanize==4.13.0
-loguru==0.6.0
-numpy==2.3.3
-packaging==25.0
-pandas==2.3.3
-pyarrow==21.0.0
-pycparser==2.21
-pyreaddbc==1.2.0
-pysus==1.0.0
-python-dateutil==2.8.2
-pytz==2025.2
-PyYAML==6.0.3
-regex==2025.9.18
-six==1.17.0
-tqdm==4.64.0
-typing_extensions==4.15.0
-tzdata==2025.2
-tzlocal==5.3.1
-Unidecode==1.4.0
-urllib3==1.26.20
-urwid==2.6.16
-wcwidth==0.2.14
-wget==3.2
+# Polars para manipulação eficiente de grandes volumes de dados
+polars==0.27.17
+
+# PyArrow para leitura e escrita de Parquet
+pyarrow==12.0.1
+
+# pysus para baixar dados do SUS
+pysus==0.4.0
+
+# Dependências opcionais para notebooks (caso você use Jupyter)
+notebook==7.0.0
+ipython==8.16.2
+
+# Dependências gerais úteis
+pandas==2.2.0
+numpy==1.26.2

--- a/transform/process_brazil.py
+++ b/transform/process_brazil.py
@@ -1,0 +1,129 @@
+import polars as pl
+from pathlib import Path
+import time
+
+# Caminhos
+PROJETO_ROOT = Path(__file__).resolve().parent.parent
+RAW_FILE = PROJETO_ROOT / "data/processed/am_2024_consolidado_final.zstd.parquet"
+PROCESSED_FILE = PROJETO_ROOT / "data/processed/am_2024_tratado.zstd.parquet"
+
+# Mapeamento de nomes de colunas
+RENAME_MAP = {
+    "AP_MVM": "data_movimento",
+    "AP_CONDIC": "tipo_gestao",
+    "AP_GESTAO": "codigo_uf_municipio_gestao",
+    "AP_CODUNI": "codigo_estabelecimento",
+    "AP_AUTORIZ": "numero_apac",
+    "AP_CMP": "data_atendimento",
+    "AP_PRIPAL": "procedimento_principal",
+    "AP_VL_AP": "valor_apac",
+    "AP_UFMUN": "uf_municipio_estabelecimento",
+    "AP_TPUPS": "tipo_estabelecimento",
+    "AP_TIPPRE": "tipo_prestador",
+    "AP_MN_IND": "manutencao_individual",
+    "AP_CNPJCPF": "cnpj_estabelecimento",
+    "AP_CNPJMNT": "cnpj_mantenedora",
+    "AP_CNSPCN": "cns_paciente",
+    "AP_COIDADE": "codigo_idade",
+    "AP_NUIDADE": "idade",
+    "AP_SEXO": "sexo",
+    "AP_RACACOR": "raca_cor",
+    "AP_MUNPCN": "uf_municipio_residencia",
+    "AP_UFNACIO": "codigo_nacionalidade",
+    "AP_CEPPCN": "cep",
+    "AP_UFDIF": "uf_diferente",
+    "AP_MNDIF": "municipio_diferente",
+    "AP_DTINIC": "data_inicio",
+    "AP_DTFIM": "data_fim",
+    "AP_TPATEN": "tipo_atendimento",
+    "AP_TPAPAC": "indicador_apac",
+    "AP_MOTSAI": "motivo_saida",
+    "AP_OBITO": "obito",
+    "AP_ENCERR": "encerramento",
+    "AP_PERMAN": "permanencia",
+    "AP_ALTA": "alta",
+    "AP_TRANSF": "transferencia",
+    "AP_DTOCOR": "data_ocorrencia",
+    "AP_CODEMI": "codigo_orgao_emissor",
+    "AP_CATEND": "carater_atendimento",
+    "AP_APACANT": "numero_apac_anterior",
+    "AP_UNISOL": "estabelecimento_solicitante",
+    "AP_DTSOLIC": "data_solicitacao",
+    "AP_DTAUT": "data_autorizacao",
+    "AP_CIDCAS": "cid_causas_associadas",
+    "AP_CIDPRI": "cid_principal",
+    "AP_CIDSEC": "cid_secundario",
+    "AP_ETNIA": "etnia",
+    "AM_PESO": "peso",
+    "AM_ALTURA": "altura",
+    "AM_TRANSPL": "transplante",
+    "AM_QTDTRAN": "quantidade_transplantes",
+    "AM_GESTANT": "gestante"
+}
+
+# Tipos numéricos
+DTYPE_MAP = {
+    "valor_apac": pl.Float32,
+    "idade": pl.Int32,
+    "peso": pl.Float32,
+    "altura": pl.Float32
+}
+
+# Colunas de data
+DATE_COLS = [
+    "data_movimento", "data_atendimento", "data_inicio", "data_fim",
+    "data_ocorrencia", "data_solicitacao", "data_autorizacao"
+]
+
+# Função de parsing de datas compatível com Polars >=0.23
+def parse_date_expression(col_name: str):
+    return pl.when(pl.col(col_name).str.len_chars() == 8).then(
+        pl.col(col_name).str.strptime(pl.Date, "%Y%m%d", strict=False)
+    ).otherwise(
+        pl.col(col_name).str.strptime(pl.Date, "%Y%m", strict=False)
+    )
+
+
+def main():
+    print("🔹 Iniciando processamento nacional com Polars LazyFrame...")
+    start = time.time()
+
+    # Leitura preguiçosa do parquet
+    df = pl.scan_parquet(RAW_FILE)
+
+    # Renomeia colunas
+    df = df.rename(RENAME_MAP)
+
+    # Obter colunas do LazyFrame para evitar warnings
+    schema_cols = df.collect_schema().names()
+
+    # Conversões numéricas
+    numeric_exprs = [
+        pl.col(c).cast(dtype, strict=False).alias(c)
+        for c, dtype in DTYPE_MAP.items()
+        if c in schema_cols
+    ]
+
+    # Conversões de datas
+    date_exprs = [parse_date_expression(c) for c in DATE_COLS if c in schema_cols]
+
+    # Aplica todas as conversões de uma vez
+    df = df.with_columns(numeric_exprs + date_exprs)
+
+    # Salva de forma preguiçosa com compressão ZSTD
+    print("Gravando arquivo tratado com compressão ZSTD...")
+    df.sink_parquet(
+        PROCESSED_FILE,
+        compression="zstd",
+        compression_level=7
+    )
+
+    elapsed = (time.time() - start) / 60
+    size_gb = PROCESSED_FILE.stat().st_size / (1024 ** 3)
+
+    print(f"✅ Arquivo tratado salvo em: {PROCESSED_FILE}")
+    print(f"📦 Tamanho final: {size_gb:.2f} GB")
+    print(f"⏱️ Tempo total de execução: {elapsed:.2f} minutos")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Necessário migrar para Polars para lidar com o volume de 35 milhões de linhas de forma eficiente, resolvendo problemas de escalabilidade e memória com Pandas.